### PR TITLE
HDS style-guide hotfix add script to run fractal web UI server via npm

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "@frctl/fractal": "^1.2.0",
     "@frctl/mandelbrot": "^1.2.1"
+  },
+  "scripts": {
+    "fractal-start": "fractal start --sync"
   }
 }


### PR DESCRIPTION

With this edit in place, a user can run a local copy of the style guide in a browser 
by navigating to the style-guide root and typing the command, 
npm run fractal-start 